### PR TITLE
Try StaticLiveServerTestCase from Django 1.7 before LiveServerTestCase.

### DIFF
--- a/aloe_django/__init__.py
+++ b/aloe_django/__init__.py
@@ -11,7 +11,7 @@ from django.core.exceptions import ImproperlyConfigured
 # does the same as the first in older django versions
 try:
     from django.contrib.staticfiles.testing import (
-            StaticLiveServerTestCase as LiveServerTestCase)
+        StaticLiveServerTestCase as LiveServerTestCase)
 except ImportError:
     from django.test import LiveServerTestCase
 

--- a/aloe_django/__init__.py
+++ b/aloe_django/__init__.py
@@ -6,12 +6,19 @@ Django integration for Aloe
 
 from django.core.exceptions import ImproperlyConfigured
 
+# To enable static files transparently, uses the StaticLiveServerTestCase,
+# available in Django 1.8, or fall back to default LiveServerTestCase, that
+# does the same as the first in older django versions
 try:
-    import django.test
+    from django.contrib.staticfiles.testing import StaticLiveServerTestCase as LiveServerTestCase
+except ImportError:
+    from django.test import LiveServerTestCase
+
+try:
 
     from aloe.testclass import TestCase as AloeTestCase
 
-    class TestCase(django.test.LiveServerTestCase, AloeTestCase):
+    class TestCase(LiveServerTestCase, AloeTestCase):
         """
         Base test class for Django Gherkin tests.
 

--- a/aloe_django/__init__.py
+++ b/aloe_django/__init__.py
@@ -10,7 +10,8 @@ from django.core.exceptions import ImproperlyConfigured
 # available in Django 1.8, or fall back to default LiveServerTestCase, that
 # does the same as the first in older django versions
 try:
-    from django.contrib.staticfiles.testing import StaticLiveServerTestCase as LiveServerTestCase
+    from django.contrib.staticfiles.testing import (
+            StaticLiveServerTestCase as LiveServerTestCase)
 except ImportError:
     from django.test import LiveServerTestCase
 


### PR DESCRIPTION
Django 1.7 introduces a split in the LiveServerTestCase: before 1.7 static files are served during tests. Now you must use StaticLiveServerTestCase in order to enable [static files transparently](https://docs.djangoproject.com/en/1.8/howto/static-files/#testing).

I fix it just trying StaticLiveServerTestCase, as I consider trivial using the static files during tests. One could think this should be configurable, I'm open to suggestions  :)
