### PR TITLE
Update get_model to use name instead of model

### DIFF
--- a/aloe_django/steps/models.py
+++ b/aloe_django/steps/models.py
@@ -181,7 +181,7 @@ def get_model(model):
     """
 
     name = model.lower()
-    model = MODELS.get(model, None)
+    model = MODELS.get(name, None)
 
     assert model, "Could not locate model by name '%s'" % name
 


### PR DESCRIPTION
This function will usually raise an error due to this unless you name the model parameter exactly same to the keys in MODELS
