### PR TITLE
Remove `future` from requirements.txt.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@ aloe>=0.0.43
 cssselect>=0.7.1
 Django
 django-nose>=1.4.2
-future
 PyYAML


### PR DESCRIPTION
Since `future` is already a requirement of `aloe`, removing the explicit
inclusion of `future` in this app's requirements.txt eliminates the
potential for "requirements drift" between aloe's required version of
`future` and this app's required version of `future`.

For an example of this potential discrepancy between required versions of `future`, see https://github.com/aloetesting/aloe/pull/101
