### PR TITLE
Fix the documentation link for readthedocs.org.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Install:
 
     pip install aloe_django
 
-Read the [documentation](http://aloe.readthedocs.org/projects/aloe_django/en/latest/).
+Read the [documentation](http://aloe_django.readthedocs.org/en/latest/).
 
 Aloe and Aloe-Django are based on [Lettuce](http://lettuce.it/).
 


### PR DESCRIPTION
The current link is broken probably because of a repo split?  We should verify that docs are building properly.
