### PR TITLE
Do not crash when dumping models with unicode characters

### DIFF
--- a/aloe_django/steps/models.py
+++ b/aloe_django/steps/models.py
@@ -206,7 +206,7 @@ def _dump_model(model, attrs=None):
         )))
 
     print(', '.join(
-        '{0}={1}'.format(field, value)
+        u'{0}={1}'.format(field, value)
         for field, value in fields
     ))
 

--- a/tests/integration/django/dill/leaves/features/existence.feature
+++ b/tests/integration/django/dill/leaves/features/existence.feature
@@ -7,6 +7,7 @@ Feature: Check models existence
       | name             | area | raining |
       | Octopus's Garden | 120  | true    |
       | Covent Garden    | 200  | true    |
+      | 日本語 Garden    | 130  | false   |
     And garden with name "Secret Garden" has fruit in the database:
       | name  | ripe_by    |
       | Apple | 2013-07-02 |


### PR DESCRIPTION
When using step `And my model should be present in the database:` it
will dump the database model's table if the expected record can't be
found.
This prevent the dumnping to fail if the record contains unicode
characters.
