### PR TITLE
Fixes issues with django 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,6 @@ env:
 - DJANGO_VERSION=1.11.*
 matrix:
   exclude:
-    - python: '3.7'
-      env: DJANGO_VERSION=1.11.*
-    - python: '3.6'
-      env: DJANGO_VERSION=1.11.*
-    - python: '3.5'
-      env: DJANGO_VERSION=1.11.*
-    - python: '3.4'
-      env: DJANGO_VERSION=1.11.*
     - python: '3.4'
       env: DJANGO_VERSION=2.1.*
     - python: '3.4'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,36 @@
 language: python
+dist: xenial
 python:
+- '3.7'
 - '3.6'
 - '3.5'
 - '3.4'
 - '2.7'
 env:
+- DJANGO_VERSION=2.2.*
 - DJANGO_VERSION=2.1.*
 - DJANGO_VERSION=2.0.*
 - DJANGO_VERSION=1.11.*
-- DJANGO_VERSION=1.10.*
-- DJANGO_VERSION=1.9.*
-- DJANGO_VERSION=1.8.*
 matrix:
   exclude:
+    - python: '3.7'
+      env: DJANGO_VERSION=1.11.*
     - python: '3.6'
-      env: DJANGO_VERSION=1.8.*
-    - python: '3.6'
-      env: DJANGO_VERSION=1.9.*
-    - python: '3.6'
-      env: DJANGO_VERSION=1.10.*
+      env: DJANGO_VERSION=1.11.*
+    - python: '3.5'
+      env: DJANGO_VERSION=1.11.*
+    - python: '3.4'
+      env: DJANGO_VERSION=1.11.*
+    - python: '3.4'
+      env: DJANGO_VERSION=2.1.*
+    - python: '3.4'
+      env: DJANGO_VERSION=2.2.*
     - python: '2.7'
       env: DJANGO_VERSION=2.0.*
     - python: '2.7'
       env: DJANGO_VERSION=2.1.*
-    - python: '3.4'
-      env: DJANGO_VERSION=2.1.*
+    - python: '2.7'
+      env: DJANGO_VERSION=2.2.*
 install:
 - pip install Django==$DJANGO_VERSION
 - pip install -r requirements.txt

--- a/aloe_django/management/commands/harvest.py
+++ b/aloe_django/management/commands/harvest.py
@@ -27,7 +27,11 @@ class Command(TestCommand):
         Set the default Gherkin test runner for its options to be parsed.
         """
 
+        # django < 2.2
         self.test_runner = test_runner_class
+        # django >= 2.2
+        if '--testrunner' not in argv:
+            argv += ['--testrunner', test_runner_class]
         super(Command, self).run_from_argv(argv)
 
     def handle(self, *test_labels, **options):

--- a/aloe_django/management/commands/harvest.py
+++ b/aloe_django/management/commands/harvest.py
@@ -33,12 +33,3 @@ class Command(TestCommand):
         if '--testrunner' not in argv:
             argv += ['--testrunner', test_runner_class]
         super(Command, self).run_from_argv(argv)
-
-    def handle(self, *test_labels, **options):
-        """
-        Set the default Gherkin test runner.
-        """
-        if not options.get('testrunner', None):
-            options['testrunner'] = test_runner_class
-
-        return super(Command, self).handle(*test_labels, **options)

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,11 @@ if __name__ == '__main__':
             classifiers=[
                 'License :: OSI Approved :: '
                 + 'GNU General Public License v3 or later (GPLv3+)',
+                'Framework :: Django',
+                'Framework :: Django :: 1.11',
+                'Framework :: Django :: 2.0',
+                'Framework :: Django :: 2.1',
+                'Framework :: Django :: 2.2',
                 'Programming Language :: Python',
                 'Programming Language :: Python :: 2',
                 'Programming Language :: Python :: 3',


### PR DESCRIPTION
* Fixes `harvest` bug in Django 2.2. (wouldn't recognize test_runner unless passed as an argument to the command ie `python manage.py harvest --test-runner ....`)
* Removes support for dj 1.8/1.9/1.10 (see https://www.djangoproject.com/download/#supported-versions)
